### PR TITLE
Breaks up plant profile page into smaller components and adds features

### DIFF
--- a/src/frontend/containers/ChangePasswordPage/index.jsx
+++ b/src/frontend/containers/ChangePasswordPage/index.jsx
@@ -76,7 +76,7 @@ class ChangePasswordPage extends React.Component {
                 type="password"
                 className="form-control mt-2"
                 autoComplete="on"
-                placeholder="Current Password*"
+                placeholder="Current Password"
                 onChange={(event) => this.setState({
                   currentpwd: event.target.value,
                 })}
@@ -86,7 +86,7 @@ class ChangePasswordPage extends React.Component {
                 type="password"
                 className="form-control mt-2"
                 autoComplete="on"
-                placeholder="New Password*"
+                placeholder="New Password"
                 onChange={(event) => this.setState({
                   newpwd: event.target.value,
                 })}
@@ -96,7 +96,7 @@ class ChangePasswordPage extends React.Component {
                 type="password"
                 className="form-control mt-2"
                 autoComplete="on"
-                placeholder="Confirm New Password*"
+                placeholder="Confirm New Password"
                 onChange={(event) => this.setState({
                   confirmpwd: event.target.value,
                 })}

--- a/src/frontend/containers/EditPlantProfilePage/index.jsx
+++ b/src/frontend/containers/EditPlantProfilePage/index.jsx
@@ -81,16 +81,9 @@ class EditPlantProfilePage extends React.Component {
 
   getGrowthPictures() {
     const { match: { params: { id } } } = this.props;
-    const growthPics = {};
-    this.setState({ growthPics });
 
-    getPetGrowthPictures(id, (pictureRef, index) => {
-      pictureRef.getDownloadURL()
-        .then((picture) => {
-          growthPics[index] = picture;
-          this.setState({ growthPics });
-        })
-        .catch(() => {});
+    getPetGrowthPictures(id).then((growthPics) => {
+      this.setState({ growthPics });
     });
   }
 
@@ -241,7 +234,7 @@ class EditPlantProfilePage extends React.Component {
     const today = (new Date()).toISOString().split('T')[0];
     const past = new Date((new Date().getFullYear() - 50)).toISOString().split('T')[0];
 
-    const growthPicCards = Object.entries(growthPics)
+    const growthPicCards = Object.entries(growthPics || [])
       .sort(([i], [j]) => {
         if (new Date(i) < new Date(j)) return -1;
         return 1;
@@ -346,7 +339,7 @@ class EditPlantProfilePage extends React.Component {
                 </DropdownToggle>
                 <DropdownMenu required>
                   {plantList.map((plant) => (
-                    <DropdownItem onClick={this.handleDropdown}>{plant}</DropdownItem>
+                    <DropdownItem onClick={this.handleDropdown} key={plant}>{plant}</DropdownItem>
                   ))}
                 </DropdownMenu>
               </Dropdown>

--- a/src/frontend/containers/EditPlantProfilePage/index.jsx
+++ b/src/frontend/containers/EditPlantProfilePage/index.jsx
@@ -214,9 +214,9 @@ class EditPlantProfilePage extends React.Component {
     });
   }
 
-  handleDropdown(e) {
+  handleDropdown(type) {
     const { pet } = this.state;
-    this.setState({ pet: { ...pet, type: e.currentTarget.textContent } });
+    this.setState({ pet: { ...pet, type } });
   }
 
   toggleDropdown() {
@@ -230,7 +230,6 @@ class EditPlantProfilePage extends React.Component {
       profilePictureFeedback, profilePictureValidationState, resetProfilePicInput,
       growthPictureFeedback, growthPictureValidationState, resetGrowthPicInput } = this.state;
     const { store: { plants } } = this.props;
-    const plantList = Object.keys(plants);
     const today = (new Date()).toISOString().split('T')[0];
     const past = new Date((new Date().getFullYear() - 50)).toISOString().split('T')[0];
 
@@ -335,11 +334,16 @@ class EditPlantProfilePage extends React.Component {
               <Dropdown name="type" isOpen={this.state.dropdownOpen} toggle={this.toggleDropdown}>
                 <DropdownToggle caret id="size-dropdown">
                   { /* eslint-disable-next-line react/destructuring-assignment */}
-                  {this.state.pet.type}
+                  {plants[this.state.pet.type]?.name}
                 </DropdownToggle>
                 <DropdownMenu required>
-                  {plantList.map((plant) => (
-                    <DropdownItem onClick={this.handleDropdown} key={plant}>{plant}</DropdownItem>
+                  {Object.entries(plants).map(([key, plant]) => (
+                    <DropdownItem
+                      key={key}
+                      onClick={() => this.handleDropdown(key)}
+                    >
+                      {plant.name}
+                    </DropdownItem>
                   ))}
                 </DropdownMenu>
               </Dropdown>

--- a/src/frontend/containers/EditPlantProfilePage/index.jsx
+++ b/src/frontend/containers/EditPlantProfilePage/index.jsx
@@ -337,14 +337,17 @@ class EditPlantProfilePage extends React.Component {
                   {plants[this.state.pet.type]?.name}
                 </DropdownToggle>
                 <DropdownMenu required>
-                  {Object.entries(plants).map(([key, plant]) => (
-                    <DropdownItem
-                      key={key}
-                      onClick={() => this.handleDropdown(key)}
-                    >
-                      {plant.name}
-                    </DropdownItem>
-                  ))}
+                  {Object.entries(plants)
+                    // eslint-disable-next-line
+                    .sort(([_, p1], [__, p2]) => p1.name < p2.name ? -1 : 1)
+                    .map(([key, plant]) => (
+                      <DropdownItem
+                        key={key}
+                        onClick={() => this.handleDropdown(key)}
+                      >
+                        {plant.name}
+                      </DropdownItem>
+                    ))}
                 </DropdownMenu>
               </Dropdown>
             </Form.Group>

--- a/src/frontend/containers/NewPlantProfilePage/index.jsx
+++ b/src/frontend/containers/NewPlantProfilePage/index.jsx
@@ -253,14 +253,17 @@ class NewPlantProfilePage extends React.Component {
                 {plants[this.state.type]?.name}
               </DropdownToggle>
               <DropdownMenu required>
-                {Object.entries(plants).map(([key, plant]) => (
-                  <DropdownItem
-                    key={key}
-                    onClick={() => this.handleDropdown(key)}
-                  >
-                    {plant.name}
-                  </DropdownItem>
-                ))}
+                {Object.entries(plants)
+                  // eslint-disable-next-line
+                  .sort(([_, p1], [__, p2]) => p1.name < p2.name ? -1 : 1)
+                  .map(([key, plant]) => (
+                    <DropdownItem
+                      key={key}
+                      onClick={() => this.handleDropdown(key)}
+                    >
+                      {plant.name}
+                    </DropdownItem>
+                  ))}
               </DropdownMenu>
             </Dropdown>
           </Form.Group>

--- a/src/frontend/containers/NewPlantProfilePage/index.jsx
+++ b/src/frontend/containers/NewPlantProfilePage/index.jsx
@@ -153,8 +153,8 @@ class NewPlantProfilePage extends React.Component {
     });
   }
 
-  handleDropdown(e) {
-    this.setState({ type: e.currentTarget.textContent });
+  handleDropdown(type) {
+    this.setState({ type });
   }
 
   toggleDropdown() {
@@ -168,7 +168,6 @@ class NewPlantProfilePage extends React.Component {
     const { name, birth, ownedSince,
       profilePic, profilePictureFeedback,
       profilePictureValidationState, resetProfilePicInput } = this.state;
-    const plantList = Object.keys(plants);
     const today = (new Date()).toISOString().split('T')[0];
     const past = new Date((new Date().getFullYear() - 50)).toISOString().split('T')[0];
 
@@ -251,11 +250,16 @@ class NewPlantProfilePage extends React.Component {
             <Dropdown name="type" isOpen={this.state.dropdownOpen} toggle={this.toggleDropdown}>
               <DropdownToggle caret id="size-dropdown">
                 { /* eslint-disable-next-line react/destructuring-assignment */}
-                {this.state.type}
+                {plants[this.state.type]?.name}
               </DropdownToggle>
               <DropdownMenu required>
-                {plantList.map((plant) => (
-                  <DropdownItem key={plant} onClick={this.handleDropdown}>{plant}</DropdownItem>
+                {Object.entries(plants).map(([key, plant]) => (
+                  <DropdownItem
+                    key={key}
+                    onClick={() => this.handleDropdown(key)}
+                  >
+                    {plant.name}
+                  </DropdownItem>
                 ))}
               </DropdownMenu>
             </Dropdown>

--- a/src/frontend/containers/PlantProfilePage/CareCalendar.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareCalendar.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+
+class CareCalendar extends React.PureComponent {
+  render() {
+    const { events } = this.props;
+
+    return (
+      <div>
+        <h2>Care Calendar</h2>
+
+        <div id="calendar">
+          <FullCalendar
+            plugins={[dayGridPlugin]}
+            initialView="dayGridMonth"
+            weekends
+            events={events}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+CareCalendar.propTypes = {
+  events: PropTypes.array.isRequired,
+};
+
+export default CareCalendar;

--- a/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
@@ -10,9 +10,9 @@ class CareFrequency extends React.PureComponent {
     super();
 
     this.markWatered = this.markWatered.bind(this);
-    this.markFertilized = this.markWatered.bind(this);
-    this.markTurned = this.markWatered.bind(this);
-    this.markFed = this.markWatered.bind(this);
+    this.markFertilized = this.markFertilized.bind(this);
+    this.markTurned = this.markTurned.bind(this);
+    this.markFed = this.markFed.bind(this);
   }
 
   markWatered() {
@@ -36,17 +36,17 @@ class CareFrequency extends React.PureComponent {
   }
 
   render() {
-    const { pet, waterFreq, fertFreq, feedFreq } = this.props;
+    const { pet, waterFreq, fertFreq, feedFreq, carnivorous } = this.props;
 
     const today = getToday();
     const hasWateredToday = !!pet?.watered?.history?.[today];
     const hasFertilizedToday = !!pet?.fertilized?.history?.[today];
     const hasTurnedToday = !!pet?.turned?.history?.[today];
-    const hasFedToday = false;
+    const hasFedToday = !!pet?.fed?.history?.[today];
 
     let feedFreqJSX;
     let feedButtonJSX;
-    if (feedFreq) {
+    if (carnivorous) {
       feedFreqJSX = <p>{`Feed Frequency: Every ${feedFreq} days`}</p>;
       feedButtonJSX = (
         <Button
@@ -120,10 +120,14 @@ CareFrequency.propTypes = {
     turned: PropTypes.shape({
       history: PropTypes.object,
     }).isRequired,
+    fed: PropTypes.shape({
+      history: PropTypes.object,
+    }).isRequired,
   }).isRequired,
   waterFreq: PropTypes.number.isRequired,
   fertFreq: PropTypes.number.isRequired,
   feedFreq: PropTypes.any.isRequired,
+  carnivorous: PropTypes.bool.isRequired,
   onChange: PropTypes.func,
 };
 

--- a/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { addDate } from '../../store/actions/pets';
 
-const getToday = () => new Date().toISOString().slice(0, 10);
+const getToday = () => {
+  const now = new Date();
+  return new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000).toISOString().slice(0, 10);
+};
 
 class CareFrequency extends React.PureComponent {
   constructor() {

--- a/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import { addDate } from '../../store/actions/pets';
+
+const getToday = () => new Date().toISOString().slice(0, 10);
+
+class CareFrequency extends React.PureComponent {
+  constructor() {
+    super();
+
+    this.markWatered = this.markWatered.bind(this);
+    this.markFertilized = this.markWatered.bind(this);
+    this.markTurned = this.markWatered.bind(this);
+    this.markFed = this.markWatered.bind(this);
+  }
+
+  markWatered() {
+    const { id, onChange } = this.props;
+    addDate(id, 'watered', getToday()).then(onChange);
+  }
+
+  markFertilized() {
+    const { id, onChange } = this.props;
+    addDate(id, 'fertilized', getToday()).then(onChange);
+  }
+
+  markTurned() {
+    const { id, onChange } = this.props;
+    addDate(id, 'turned', getToday()).then(onChange);
+  }
+
+  markFed() {
+    const { id, onChange } = this.props;
+    addDate(id, 'fed', getToday()).then(onChange);
+  }
+
+  render() {
+    const { pet, waterFreq, fertFreq, feedFreq } = this.props;
+
+    const today = getToday();
+    const hasWateredToday = !!pet?.watered?.history?.[today];
+    const hasFertilizedToday = !!pet?.fertilized?.history?.[today];
+    const hasTurnedToday = !!pet?.turned?.history?.[today];
+    const hasFedToday = false;
+
+    let feedFreqJSX;
+    let feedButtonJSX;
+    if (feedFreq) {
+      feedFreqJSX = <p>{`Feed Frequency: Every ${feedFreq} days`}</p>;
+      feedButtonJSX = (
+        <Button
+          type="button"
+          disabled={hasFedToday}
+          onClick={hasFedToday ? () => {} : this.markFed}
+        >
+          { hasFedToday ? 'Fed' : 'Feed' }
+        </Button>
+      );
+    }
+
+    return (
+      <div>
+        <h2>Care Frequency</h2>
+
+        <span>
+          <div>
+            <p>{`Water Frequency: Every ${waterFreq} days`}</p>
+            <p>{`Fertilize Frequency: Every ${fertFreq} days`}</p>
+            <p>{`Turn Frequency: Every ${fertFreq} days`}</p>
+            {feedFreqJSX}
+          </div>
+
+          <div id="care-buttons">
+            <Button
+              type="button"
+              disabled={hasWateredToday}
+              onClick={hasWateredToday ? () => {} : this.markWatered}
+            >
+              { hasWateredToday ? 'Watered' : 'Water' }
+            </Button>
+
+            <Button
+              type="button"
+              disabled={hasFertilizedToday}
+              onClick={hasFertilizedToday ? () => {} : this.markFertilized}
+            >
+              { hasFertilizedToday ? 'Fertilized' : 'Fertilize' }
+            </Button>
+
+            <Button
+              type="button"
+              disabled={hasTurnedToday}
+              onClick={hasTurnedToday ? () => {} : this.markTurned}
+            >
+              { hasTurnedToday ? 'Turned' : 'Turn' }
+            </Button>
+
+            {feedButtonJSX}
+          </div>
+        </span>
+      </div>
+    );
+  }
+}
+
+CareFrequency.defaultProps = {
+  onChange: () => {},
+};
+
+CareFrequency.propTypes = {
+  id: PropTypes.string.isRequired,
+  pet: PropTypes.shape({
+    watered: PropTypes.shape({
+      history: PropTypes.object,
+    }).isRequired,
+    fertilized: PropTypes.shape({
+      history: PropTypes.object,
+    }).isRequired,
+    turned: PropTypes.shape({
+      history: PropTypes.object,
+    }).isRequired,
+  }).isRequired,
+  waterFreq: PropTypes.number.isRequired,
+  fertFreq: PropTypes.number.isRequired,
+  feedFreq: PropTypes.any.isRequired,
+  onChange: PropTypes.func,
+};
+
+export default CareFrequency;

--- a/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
+++ b/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class GeneralInformation extends React.PureComponent {
+  render() {
+    const { speciesName, scientificName, description, birth, ownedSince } = this.props;
+
+    return (
+      <div>
+        <h2>General Information</h2>
+        <p>{`Species Name: ${speciesName}`}</p>
+        <p>{`Scientific Name: ${scientificName}`}</p>
+        <p>{`Description: ${description}`}</p>
+        <p>{`Born: ${birth}`}</p>
+        <p>{`Owned Since: ${ownedSince}`}</p>
+      </div>
+    );
+  }
+}
+
+GeneralInformation.propTypes = {
+  speciesName: PropTypes.string.isRequired,
+  scientificName: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  birth: PropTypes.string.isRequired,
+  ownedSince: PropTypes.string.isRequired,
+};
+
+export default GeneralInformation;

--- a/src/frontend/containers/PlantProfilePage/GrowthPictures.jsx
+++ b/src/frontend/containers/PlantProfilePage/GrowthPictures.jsx
@@ -6,8 +6,6 @@ class GrowthPictures extends React.PureComponent {
   render() {
     const { foreignPlant, pictures } = this.props;
 
-    console.log('GrowthPictures', pictures);
-
     const cards = Object.entries(pictures)
       .sort(([i], [j]) => new Date(i) - new Date(j))
       .map(([index, picture]) => (

--- a/src/frontend/containers/PlantProfilePage/GrowthPictures.jsx
+++ b/src/frontend/containers/PlantProfilePage/GrowthPictures.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card } from 'react-bootstrap';
+
+class GrowthPictures extends React.PureComponent {
+  render() {
+    const { foreignPlant, pictures } = this.props;
+
+    console.log('GrowthPictures', pictures);
+
+    const cards = Object.entries(pictures)
+      .sort(([i], [j]) => new Date(i) - new Date(j))
+      .map(([index, picture]) => (
+        <Card className="growth-pic-card" key={index}>
+          <Card.Img className="card-img" variant="top" src={picture} />
+          <Card.Body>
+            <Card.Title>{(new Date(index)).toISOString().split('T')[0]}</Card.Title>
+          </Card.Body>
+        </Card>
+      ));
+
+    const hintText = foreignPlant
+      ? 'This user hasn\'t uploaded any growth pictures yet'
+      : 'Click the edit button to add growth pictures';
+
+    return (
+      <div>
+        <h2>Growth Pictures</h2>
+        {cards?.length ? cards : <p style={{ margin: '0px' }}>{hintText}</p>}
+      </div>
+    );
+  }
+}
+
+GrowthPictures.propTypes = {
+  pictures: PropTypes.object.isRequired,
+  foreignPlant: PropTypes.bool.isRequired,
+};
+
+export default GrowthPictures;

--- a/src/frontend/containers/PlantProfilePage/ManagePlant.jsx
+++ b/src/frontend/containers/PlantProfilePage/ManagePlant.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { Button, Modal } from 'react-bootstrap';
+import { deletePet } from '../../store/actions/pets';
+
+class ManagePlant extends React.PureComponent {
+  constructor() {
+    super();
+
+    this.state = {
+      show: false,
+    };
+
+    this.toggleDeleteModal = this.toggleDeleteModal.bind(this);
+    this.edit = this.edit.bind(this);
+    this.delete = this.delete.bind(this);
+  }
+
+  toggleDeleteModal() {
+    this.setState((prevState) => ({
+      show: !prevState.show,
+    }));
+  }
+
+  edit() {
+    const { history, id, username } = this.props;
+    history.push(`/${username}/edit/${id}`);
+  }
+
+  delete() {
+    this.toggleDeleteModal();
+
+    const { history, id, username } = this.props;
+    history.push(`/${username}/edit/${id}`);
+
+    deletePet(id).then(() => {
+      history.push(`/${username}`);
+    });
+  }
+
+  render() {
+    const { pet } = this.props;
+    const { show } = this.state;
+
+    return (
+      <div>
+        <h2>Manage Plant</h2>
+        <Button type="button" onClick={this.edit}>Edit</Button>
+        <Button type="button" onClick={this.toggleDeleteModal}>Delete</Button>
+
+        <Modal show={show} onHide={this.toggleDeleteModal}>
+          <Modal.Header closeButton>
+            <Modal.Title>Delete {pet?.name}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>Are you sure you want to delete {pet?.name}?</Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={this.toggleDeleteModal}>No</Button>
+            <Button variant="primary" onClick={this.delete}>Yes</Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+ManagePlant.propTypes = {
+  history: PropTypes.object.isRequired,
+  id: PropTypes.string.isRequired,
+  pet: PropTypes.object.isRequired,
+  username: PropTypes.string.isRequired,
+};
+
+export default withRouter(ManagePlant);

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -49,7 +49,6 @@ class PlantProfilePage extends React.Component {
     this.getGrowthPictures();
 
     if (!username) return Promise.resolve();
-
     return setForeignUserPets(username, id).catch(() => history.push(`/${ownUsername}`));
   }
 
@@ -81,11 +80,11 @@ class PlantProfilePage extends React.Component {
   }
 
   getPlantType() {
-    const { store: { users, pets, account: { username: ownUsername } } } = this.props;
+    const { own, store: { users, pets, account: { username: ownUsername } } } = this.props;
     const { history, match: { params: { username, id } } } = this.props;
 
     let pet;
-    if (username && username !== ownUsername) {
+    if (!own) {
       pet = users[username] ? users[username].pets[id] : { type: '' };
     } else if (!pets[id]) {
       history.push(`/${ownUsername}`);
@@ -132,15 +131,14 @@ class PlantProfilePage extends React.Component {
   }
 
   render() {
-    const { store: { users, pets, account: { username: ownUsername } } } = this.props;
+    const { own, store: { users, pets, account: { username: ownUsername } } } = this.props;
     const { history, match: { params: { username, id } } } = this.props;
     const { speciesName, scientificName, description, carnivorous,
       waterFreq, fertFreq, feedFreq, eventList,
       profilePic, growthPics } = this.state;
-    const foreignPlant = !!username && username !== ownUsername;
 
     let pet;
-    if (foreignPlant) {
+    if (!own) {
       pet = users[username]
         ? users[username].pets[id]
         : { name: '', type: '', birth: '', ownedSince: '', watered: {}, fertilized: {}, turned: {}, fed: {} };
@@ -149,8 +147,6 @@ class PlantProfilePage extends React.Component {
     } else {
       pet = pets[id];
     }
-
-    console.log('Index', growthPics);
 
     return (
       <div>
@@ -175,7 +171,7 @@ class PlantProfilePage extends React.Component {
           </section>
 
           {
-            foreignPlant ? '' : (
+            !own ? '' : (
               <section id="care-frequency">
                 <CareFrequency
                   id={id}
@@ -195,11 +191,11 @@ class PlantProfilePage extends React.Component {
           </section>
 
           <section id="growth-pictures">
-            <GrowthPictures pictures={growthPics} foreignPlant={foreignPlant} />
+            <GrowthPictures pictures={growthPics} foreignPlant={!own} />
           </section>
 
           {
-            foreignPlant ? '' : (
+            !own ? '' : (
               <section id="manage-plant">
                 <ManagePlant id={id} pet={pet} username={ownUsername} />
               </section>
@@ -212,6 +208,7 @@ class PlantProfilePage extends React.Component {
 }
 
 PlantProfilePage.propTypes = {
+  own: PropTypes.bool.isRequired,
   history: PropTypes.object.isRequired,
   store: PropTypes.shape({
     account: PropTypes.shape({

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -74,17 +74,9 @@ class PlantProfilePage extends React.Component {
 
   getGrowthPictures() {
     const { match: { params: { id } } } = this.props;
-    const growthPics = {};
-    this.setState({ growthPics });
 
-    getPetGrowthPictures(id, (pictureRef, index) => {
-      pictureRef.getDownloadURL()
-        .then((picture) => {
-          console.log(picture, index);
-          growthPics[index] = picture;
-          this.setState({ growthPics });
-        })
-        .catch(() => {});
+    getPetGrowthPictures(id).then((growthPics) => {
+      this.setState({ growthPics });
     });
   }
 
@@ -119,16 +111,20 @@ class PlantProfilePage extends React.Component {
     const wateredDates = Object.keys(pets[id]?.watered.history || {});
     const fertilizedDates = Object.keys(pets[id]?.fertilized.history || {});
     const turnedDates = Object.keys(pets[id]?.turned.history || {});
+    const fedDates = Object.keys(pets[id]?.fed.history || {});
     // construct eventList with title and date
     const eventList = [];
     wateredDates.forEach((item) => {
-      eventList.push({ title: 'watered 💦', date: `${item}` });
+      eventList.push({ title: 'Watered 💦', date: `${item}` });
     });
     fertilizedDates.forEach((item) => {
-      eventList.push({ title: 'fertilized 🌱', date: `${item}` });
+      eventList.push({ title: 'Fertilized 🌱', date: `${item}` });
     });
     turnedDates.forEach((item) => {
-      eventList.push({ title: 'turned 💃', date: `${item}` });
+      eventList.push({ title: 'Turned 💃', date: `${item}` });
+    });
+    fedDates.forEach((item) => {
+      eventList.push({ title: 'Fed 🍽', date: `${item}` });
     });
     this.setState({
       eventList,
@@ -164,7 +160,9 @@ class PlantProfilePage extends React.Component {
           <section id="plant-name-and-information">
             <div>
               <h1>{pet?.name}</h1>
-              <img style={{ width: '150px' }} id="profile-picture" src={profilePic} alt="Profile" />
+              <span>
+                <img style={{ width: '150px' }} id="profile-picture" src={profilePic} alt="Profile" />
+              </span>
             </div>
 
             <GeneralInformation
@@ -185,6 +183,7 @@ class PlantProfilePage extends React.Component {
                   waterFreq={waterFreq}
                   fertFreq={fertFreq}
                   feedFreq={feedFreq}
+                  carnivorous={carnivorous}
                   onChange={this.fetchEventList}
                 />
               </section>

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -89,10 +89,9 @@ class PlantProfilePage extends React.Component {
     const { history, match: { params: { username, id } } } = this.props;
 
     let pet;
-    if (own) {
+    if (!own) {
       pet = users[username] ? users[username].pets[id] : { name: '', type: '' };
-    }
-    if (!pets[id]) {
+    } else if (!pets[id]) {
       history.push('/notfound');
     } else {
       pet = pets[id];
@@ -110,12 +109,8 @@ class PlantProfilePage extends React.Component {
 
   fetchEventList() {
     // fetches action history
-    const { match: { params: { id } }, history } = this.props;
+    const { match: { params: { id } } } = this.props;
     const { store: { pets } = {} } = this.props;
-    if (!pets[id]) {
-      history.push('/notfound');
-      return;
-    }
 
     const wateredDates = Object.keys(pets[id]?.watered.history || {});
     const fertilizedDates = Object.keys(pets[id]?.fertilized.history || {});

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -3,28 +3,24 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import FullCalendar from '@fullcalendar/react';
-import dayGridPlugin from '@fullcalendar/daygrid';
 import PropTypes from 'prop-types';
-import { Card, Modal, Button } from 'react-bootstrap';
 import ProfilePicture from '../../assets/images/pet_profile_picture.png';
 import Navbar from '../../components/Navbar';
-import { setForeignUserPets, getPetProfilePicture, getPetGrowthPictures,
-  addDate, deletePet } from '../../store/actions/pets';
+import { setForeignUserPets, getPetProfilePicture, getPetGrowthPictures } from '../../store/actions/pets';
 import map from '../../store/map';
 import './styles.scss';
+
+import GeneralInformation from './GeneralInformation';
+import CareFrequency from './CareFrequency';
+import CareCalendar from './CareCalendar';
+import GrowthPictures from './GrowthPictures';
+import ManagePlant from './ManagePlant';
 
 class PlantProfilePage extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onWater = this.onWater.bind(this);
-    this.onFertilize = this.onFertilize.bind(this);
-    this.onRotate = this.onRotate.bind(this);
-    this.onEdit = this.onEdit.bind(this);
-    this.onDelete = this.onDelete.bind(this);
     this.getPlantDetails = this.getPlantDetails.bind(this);
-    this.showDeleteModal = this.showDeleteModal.bind(this);
     this.getProfilePicture = this.getProfilePicture.bind(this);
     this.getGrowthPictures = this.getGrowthPictures.bind(this);
     this.fetchEventList = this.fetchEventList.bind(this);
@@ -37,7 +33,6 @@ class PlantProfilePage extends React.Component {
       carnivorous: false,
       feedFreq: '',
       fertFreq: 0,
-      showDeleteModal: false,
       profilePic: ProfilePicture,
       growthPics: {},
       eventList: [],
@@ -50,7 +45,7 @@ class PlantProfilePage extends React.Component {
 
     this.getPlantDetails();
     this.fetchEventList();
-    this.getProfilePicture();
+    // this.getProfilePicture();
     this.getGrowthPictures();
 
     if (!username) return Promise.resolve();
@@ -58,51 +53,10 @@ class PlantProfilePage extends React.Component {
     return setForeignUserPets(username, id).catch(() => history.push(`/${ownUsername}`));
   }
 
-  onWater() {
-    const { match: { params: { id } } } = this.props;
-    const today = new Date().toISOString().slice(0, 10);
-    addDate(id, 'watered', today).then(() => {
-      this.fetchEventList();
-    });
-  }
-
-  onFertilize() {
-    const today = new Date().toISOString().slice(0, 10);
-    const { match: { params: { id } } } = this.props;
-    addDate(id, 'fertilized', today).then(() => {
-      this.fetchEventList();
-    });
-  }
-
-  onRotate() {
-    const { match: { params: { id } } } = this.props;
-    const today = new Date().toISOString().slice(0, 10);
-    addDate(id, 'turned', today).then(() => {
-      this.fetchEventList();
-    });
-  }
-
-  onEdit() {
-    const {
-      history,
-      match: { params: { id: petId } },
-      store: { account: { username: userId } },
-    } = this.props;
-    history.push(`/${userId}/edit/${petId}`);
-  }
-
-  onDelete() {
-    this.showDeleteModal(false);
-
-    const {
-      history,
-      match: { params: { id } },
-      store: { account: { username: ownUsername } },
-    } = this.props;
-
-    deletePet(id).then(() => {
-      history.push(`/${ownUsername}`);
-    });
+  componentDidUpdate(prevProps) {
+    if (JSON.stringify(prevProps) !== JSON.stringify(this.props)) {
+      this.getPlantDetails();
+    }
   }
 
   getProfilePicture() {
@@ -126,6 +80,7 @@ class PlantProfilePage extends React.Component {
     getPetGrowthPictures(id, (pictureRef, index) => {
       pictureRef.getDownloadURL()
         .then((picture) => {
+          console.log(picture, index);
           growthPics[index] = picture;
           this.setState({ growthPics });
         })
@@ -139,7 +94,7 @@ class PlantProfilePage extends React.Component {
 
     let pet;
     if (username && username !== ownUsername) {
-      pet = users[username] ? users[username].pets[id] : { name: '', type: '' };
+      pet = users[username] ? users[username].pets[id] : { type: '' };
     } else if (!pets[id]) {
       history.push(`/${ownUsername}`);
     } else {
@@ -151,7 +106,9 @@ class PlantProfilePage extends React.Component {
   getPlantDetails() {
     const { store: { plants } } = this.props;
     const type = this.getPlantType();
-    this.setState({ ...plants[type] });
+    const plant = plants[type];
+
+    this.setState({ ...plants[type], speciesName: plant?.name || '' });
   }
 
   fetchEventList() {
@@ -159,9 +116,9 @@ class PlantProfilePage extends React.Component {
     const { match: { params: { id } } } = this.props;
     const { store: { pets } = {} } = this.props;
 
-    const wateredDates = Object.keys(pets[id].watered.history || {});
-    const fertilizedDates = Object.keys(pets[id].fertilized.history || {});
-    const turnedDates = Object.keys(pets[id].turned.history || {});
+    const wateredDates = Object.keys(pets[id]?.watered.history || {});
+    const fertilizedDates = Object.keys(pets[id]?.fertilized.history || {});
+    const turnedDates = Object.keys(pets[id]?.turned.history || {});
     // construct eventList with title and date
     const eventList = [];
     wateredDates.forEach((item) => {
@@ -178,151 +135,77 @@ class PlantProfilePage extends React.Component {
     });
   }
 
-  showDeleteModal(cond) {
-    this.setState({ showDeleteModal: cond });
-  }
-
   render() {
     const { store: { users, pets, account: { username: ownUsername } } } = this.props;
     const { history, match: { params: { username, id } } } = this.props;
     const { speciesName, scientificName, description, carnivorous,
       waterFreq, fertFreq, feedFreq, eventList,
       profilePic, growthPics } = this.state;
+    const foreignPlant = !!username && username !== ownUsername;
 
     let pet;
-    if (username && username !== ownUsername) {
-      pet = users[username] ? users[username].pets[id] : { name: '', type: '', birth: '', ownedSince: '' };
+    if (foreignPlant) {
+      pet = users[username]
+        ? users[username].pets[id]
+        : { name: '', type: '', birth: '', ownedSince: '', watered: {}, fertilized: {}, turned: {}, fed: {} };
     } else if (!pets[id]) {
       history.push('/notfound');
     } else {
       pet = pets[id];
     }
 
-    const today = new Date().toISOString().slice(0, 10);
-    const hasWateredToday = !!pet?.watered?.history?.[today];
-    const hasFertilizedToday = !!pet?.fertilized?.history?.[today];
-    const hasTurnedToday = !!pet?.turned?.history?.[today];
-
-    const { showDeleteModal: show } = this.state;
-
-    const growthPicCards = Object.entries(growthPics)
-      .sort(([i], [j]) => {
-        if (new Date(i) < new Date(j)) return -1;
-        return 1;
-      })
-      .map(([index, picture]) => (
-        <Card className="growth-pic-card" key={index}>
-          <Card.Img className="card-img" variant="top" src={picture} />
-          <Card.Body>
-            <Card.Title>{(new Date(index)).toISOString().split('T')[0]}</Card.Title>
-          </Card.Body>
-        </Card>
-      ));
+    console.log('Index', growthPics);
 
     return (
       <div>
         <Navbar />
 
         <div id="plant-profile-page" className="container">
-          <h1>{pet?.name}</h1>
-          <img style={{ width: '150px' }} id="profile-picture" src={profilePic} alt="Profile" />
-          <h2>General Information</h2>
-          <p>
-            Species Name:
-            {' '}
-            {speciesName}
-          </p>
-          <p>
-            Scientific Name:
-            {' '}
-            <i>{scientificName}</i>
-          </p>
-          <p>{description}</p>
-          <p>
-            Rotation Schedule: 7 Days
-          </p>
-          <p>
-            Water Schedule:
-            {' '}
-            {waterFreq}
-            {' '}
-            Days
-          </p>
-          <p>
-            Fertilization Schedule:
-            {' '}
-            {fertFreq}
-            {' '}
-            Days
-          </p>
-          <p>
-            This plant
-            {' '}
-            {carnivorous}
-            {carnivorous ? 'is' : 'is not'}
-            {' '}
-            carnivorous and hence you
-            {' '}
-            {carnivorous ? 'must' : 'must not'}
-            {' '}
-            feed it.
-          </p>
-          <p>
-            {carnivorous ? 'Feed Schedule: ' : ''}
-            {carnivorous ? feedFreq : ''}
-            {carnivorous ? ' Days' : ''}
-          </p>
-          <p>
-            <i>{pet?.name}</i>
-            {' '}
-            was born on
-            {' '}
-            {pet?.birth}
-            .
-          </p>
-          <p>
-            You have owned
-            {' '}
-            <i>{pet?.name}</i>
-            {' '}
-            since
-            {' '}
-            {pet?.ownedSince}
-            .
-          </p>
-          <button type="button" disabled={hasWateredToday} onClick={hasWateredToday ? () => {} : this.onWater}> Water </button>
-          <button type="button" disabled={hasFertilizedToday} onClick={hasFertilizedToday ? () => {} : this.onFertilize}> Fertilize </button>
-          <button type="button" disabled={hasTurnedToday} onClick={hasTurnedToday ? () => {} : this.onRotate}> Rotate </button>
-          <div className="container">
-            <button type="button" onClick={this.onEdit}> Edit </button>
-            <button type="button" onClick={() => this.showDeleteModal(true)}> Delete </button>
-          </div>
-          <div id="calendar">
-            <FullCalendar
-              plugins={[dayGridPlugin]}
-              initialView="dayGridMonth"
-              weekends
-              events={eventList}
+          <section id="plant-name-and-information">
+            <div>
+              <h1>{pet?.name}</h1>
+              <img style={{ width: '150px' }} id="profile-picture" src={profilePic} alt="Profile" />
+            </div>
+
+            <GeneralInformation
+              speciesName={speciesName}
+              scientificName={scientificName}
+              description={description}
+              birth={pet?.birth}
+              ownedSince={pet?.ownedSince}
             />
-          </div>
+          </section>
 
-          <h2>Growth Pictures</h2>
-          {growthPicCards}
+          {
+            foreignPlant ? '' : (
+              <section id="care-frequency">
+                <CareFrequency
+                  id={id}
+                  pet={pet}
+                  waterFreq={waterFreq}
+                  fertFreq={fertFreq}
+                  feedFreq={feedFreq}
+                  onChange={this.fetchEventList}
+                />
+              </section>
+            )
+          }
 
-          <Modal show={show} onHide={() => this.showDeleteModal(false)}>
-            <Modal.Header closeButton>
-              <Modal.Title>Delete {pet?.name}</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>Are you sure you want to delete {pet?.name}?</Modal.Body>
-            <Modal.Footer>
-              <Button variant="secondary" onClick={() => this.showDeleteModal(false)}>
-                No
-              </Button>
-              <Button variant="primary" onClick={this.onDelete}>
-                Yes
-              </Button>
-            </Modal.Footer>
-          </Modal>
+          <section id="care-calendar">
+            <CareCalendar events={eventList} />
+          </section>
+
+          <section id="growth-pictures">
+            <GrowthPictures pictures={growthPics} foreignPlant={foreignPlant} />
+          </section>
+
+          {
+            foreignPlant ? '' : (
+              <section id="manage-plant">
+                <ManagePlant id={id} pet={pet} username={ownUsername} />
+              </section>
+            )
+          }
         </div>
       </div>
     );

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -45,7 +45,7 @@ class PlantProfilePage extends React.Component {
 
     this.getPlantDetails();
     this.fetchEventList();
-    // this.getProfilePicture();
+    this.getProfilePicture();
     this.getGrowthPictures();
 
     if (!username) return Promise.resolve();

--- a/src/frontend/containers/PlantProfilePage/styles.scss
+++ b/src/frontend/containers/PlantProfilePage/styles.scss
@@ -2,86 +2,18 @@
 
 #plant-profile-page {
   #calendar {
-    width: 400px;
     margin: 0 auto;
     font-size: 10px;
+
+    .fc-event-title-container {
+      font-size: 14px;
+    }
   }
-  #heatmap{
+
+  #heatmap {
     width: 200px;
     margin: 0 auto;
     font-size: 10px;
-  }
-  .react-calendar-heatmap text {
-    font-size: 10px;
-    fill: #aaa;
-  }
-
-  .react-calendar-heatmap .react-calendar-heatmap-small-text {
-    font-size: 5px;
-  }
-
-  .react-calendar-heatmap rect:hover {
-    stroke: #555;
-    stroke-width: 1px;
-  }
-
-  /*
-  * Default color scale
-  */
-
-  .react-calendar-heatmap .color-empty {
-    fill: #eeeeee;
-  }
-
-  .react-calendar-heatmap .color-filled {
-    fill: #8cc665;
-  }
-
-  /*
-  * Github color scale
-  */
-
-  .react-calendar-heatmap .color-github-0 {
-    fill: #eeeeee;
-  }
-  .react-calendar-heatmap .color-github-1 {
-    fill: #d6e685;
-  }
-  .react-calendar-heatmap .color-github-2 {
-    fill: #8cc665;
-  }
-  .react-calendar-heatmap .color-github-3 {
-    fill: #44a340;
-  }
-  .react-calendar-heatmap .color-github-4 {
-    fill: #1e6823;
-  }
-
-  /*
-  * Gitlab color scale
-  */
-
-  .react-calendar-heatmap .color-gitlab-0 {
-    fill: #ededed;
-  }
-  .react-calendar-heatmap .color-gitlab-1 {
-    fill: #acd5f2;
-  }
-  .react-calendar-heatmap .color-gitlab-2 {
-    fill: #7fa8d1;
-  }
-  .react-calendar-heatmap .color-gitlab-3 {
-    fill: #49729b;
-  }
-  .react-calendar-heatmap .color-gitlab-4 {
-    fill: #254e77;
-  }
-  .react-calendar-heatmap .color-scale-1 { fill: #d6e685; }
-  .react-calendar-heatmap .color-scale-2 { fill: #8cc665; }
-  .react-calendar-heatmap .color-scale-3 { fill: #44a340; }
-  .react-calendar-heatmap .color-scale-4 { fill: #1e6823; }
-  .photo {
-    height: 500px;
   }
 
   .growth-pic-card {
@@ -109,6 +41,12 @@
     display: flex;
     flex-direction: row;
     justify-content: space-around;
+
+    span {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+    }
   }
 
   #care-frequency {

--- a/src/frontend/containers/PlantProfilePage/styles.scss
+++ b/src/frontend/containers/PlantProfilePage/styles.scss
@@ -95,4 +95,42 @@
     max-width: 100%;
     cursor: pointer;
   }
+
+  section {
+    padding: 20px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+
+    &:last-of-type {
+      border-bottom: 0px;
+    }
+  }
+
+  #plant-name-and-information {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
+  #care-frequency {
+    span {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    #care-buttons {
+      display: flex;
+      flex-direction: column;
+
+      button {
+        margin-bottom: 16px;
+      }
+    }
+  }
+
+  #manage-plant {
+    button {
+      margin-right: 16px;
+    }
+  }
 }

--- a/src/frontend/containers/PlantProfilePage/styles.scss
+++ b/src/frontend/containers/PlantProfilePage/styles.scss
@@ -1,11 +1,18 @@
 @import "~@theme";
 
+$mint: #78C2AD;
+
 #plant-profile-page {
   #calendar {
     margin: 0 auto;
     font-size: 10px;
 
+    .fc-daygrid-event {
+      border-color: $mint;
+    }
+
     .fc-event-title-container {
+      background: $mint;
       font-size: 14px;
     }
   }

--- a/src/frontend/router/index.jsx
+++ b/src/frontend/router/index.jsx
@@ -27,9 +27,9 @@ const router = (props) => (
     <Switch>
       <Route exact path={`/${props.store.account.username}`} render={() => <MyPlantsPage />} />
       <Route exact path={`/${props.store.account.username}/new`} render={() => <NewPlantProfilePage />} />
-      <Route exact path={`/${props.store.account.username}/:id`} render={() => <PlantProfilePage />} />
+      <Route exact path={`/${props.store.account.username}/:id`} render={() => <PlantProfilePage own />} />
       <Route exact path={`/${props.store.account.username}/edit/:id`} render={() => <EditPlantProfilePage />} />
-      <Route path="/:username/:id" render={() => <PlantProfilePage />} />
+      <Route path="/:username/:id" render={() => <PlantProfilePage own={false} />} />
       <Route path="/login" render={() => <LoginPage />} />
       <Route path="/register" render={() => <RegisterPage />} />
       <Route path="/account" render={() => <AccountPage />} />

--- a/src/frontend/store/actions/pets.js
+++ b/src/frontend/store/actions/pets.js
@@ -77,7 +77,7 @@ export function getPetProfilePicture(petId, callback) {
   if (!uid) {
     return Promise.resolve();
   }
-  return firebase.database().ref(`users/${uid}/pets/${petId}`).once('value', (pet) => {
+  return firebase.database().ref(`users/${uid}/pets/${petId}`).once('value').then((pet) => {
     if (petId !== `temp-${uid}` && (!pet.exists() || !pet.val().profilePic)) {
       return Promise.resolve();
     }
@@ -131,13 +131,12 @@ export function getPetGrowthPictures(petId, callback) {
     return Promise.resolve();
   }
 
-  return firebase.database().ref(`users/${uid}/pets/${petId}`).once('value', (pet) => {
+  return firebase.database().ref(`users/${uid}/pets/${petId}`).once('value').then((pet) => {
     if (pet.exists() && pet.val().growthPics) {
-      const growthPics = pet.val().growthPics?.slice();
-      for (let i = 0; i < growthPics.length; ++i) {
-        const pictureRef = firebase.storage().ref().child(`pets/growth-pictures/${petId}@${growthPics[i]}`);
-        callback(pictureRef, growthPics[i]);
-      }
+      pet.val().growthPics?.slice().forEach((timestamp) => {
+        const pictureRef = firebase.storage().ref().child(`pets/growth-pictures/${petId}@${timestamp}`);
+        callback(pictureRef, timestamp);
+      });
     }
   });
 }


### PR DESCRIPTION
This is another big PR, so apologies in advance (and no rush).

**Optimizations:**
- Breaks the plant profile component into smaller, more manageable components
- Optimizes some of our actions that involve Firebase accesses

**Features:**
- Changes the plant type dropdown to use names instead of scientific names (and sorts these names)
- Styles much of the remaining application to fit the theme

**Bug Fixes:**
- Fixes missing species name on plant profile page
- Fixes issue where viewing another user's plants crashes the page

**Outstanding Bugs:**
- Not having a picture for a pet throws Firebase errors in the console
- Other users' plants' calendars and other information doesn't populate
- Changing a plant's type from carnivorous to non-carnivorous leaves "Fed" events in the calendar which no longer makes sense