### PR TITLE
Displays next action cycle

### DIFF
--- a/src/backend/alerts/alerts.js
+++ b/src/backend/alerts/alerts.js
@@ -115,16 +115,18 @@ cron.schedule('0 11 * * *', () => {
                 break;
               case 'rotate':
                 lastDate = e.val().turned;
-                freq = 7;
-                if (typeof (lastDate) !== 'undefined' && freq != null) {
-                  const lastActionDate = new Date(lastDate.last);
-                  const diffTime = Math.abs(new Date() - lastActionDate);
-                  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-                  if (diffDays >= freq) {
+                admin.database().ref(`/plants/${species}/rotateFreq`).once('value', (data) => {
+                  freq = data.val();
+                  if (typeof (lastDate) !== 'undefined' && freq != null) {
+                    const lastActionDate = new Date(lastDate.last);
+                    const diffTime = Math.abs(new Date() - lastActionDate);
+                    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+                    if (diffDays >= freq) {
                     /* eslint-disable-next-line max-len */
-                    sendReminder(textsOn, emailsOn, userEmail, userPhoneNumber, reminder, plantName);
+                      sendReminder(textsOn, emailsOn, userEmail, userPhoneNumber, reminder, plantName);
+                    }
                   }
-                }
+                });
                 break;
               case 'feed':
                 admin.database().ref(`/plants/${species}/feedFreq`).once('value', (data) => {

--- a/src/frontend/containers/EditPlantProfilePage/index.jsx
+++ b/src/frontend/containers/EditPlantProfilePage/index.jsx
@@ -302,7 +302,7 @@ class EditPlantProfilePage extends React.Component {
             <Form.Group controlId="location">
               <Form.Label>Plant's Location:</Form.Label>
               <Form.Control
-                required
+                
                 name="location"
                 value={pet.location}
                 onChange={this.handleChange}

--- a/src/frontend/containers/EditPlantProfilePage/index.jsx
+++ b/src/frontend/containers/EditPlantProfilePage/index.jsx
@@ -302,7 +302,7 @@ class EditPlantProfilePage extends React.Component {
             <Form.Group controlId="location">
               <Form.Label>Plant's Location:</Form.Label>
               <Form.Control
-                
+
                 name="location"
                 value={pet.location}
                 onChange={this.handleChange}

--- a/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
@@ -11,7 +11,6 @@ const getToday = () => {
 class CareFrequency extends React.PureComponent {
   constructor() {
     super();
-    console.log("callin care freq")
     this.markWatered = this.markWatered.bind(this);
     this.markFertilized = this.markFertilized.bind(this);
     this.markTurned = this.markTurned.bind(this);
@@ -39,7 +38,7 @@ class CareFrequency extends React.PureComponent {
   }
 
   render() {
-    const { pet, waterFreq, fertFreq, feedFreq, carnivorous, dead,nextCycleDates} = this.props;
+    const { pet, waterFreq, fertFreq, feedFreq, carnivorous, dead, nextCycleDates } = this.props;
 
     const today = getToday();
     const hasWateredToday = !!pet?.watered?.history?.[today];
@@ -74,8 +73,8 @@ class CareFrequency extends React.PureComponent {
             <p>{`Days remaining to next water cycle: ${nextCycleDates[0]} days`}</p>
             <p>{`Days remaining to next fertilize cycle: ${nextCycleDates[1]} days`}</p>
             <p>{`Days remaining to next rotate cycle: ${nextCycleDates[2]} days`}</p>
-            {carnivorous===1 ? (<p>{`Days remaining to next feed cycle: ${nextCycleDates[3]} days`}</p>) : '' }
-            
+            {carnivorous === 1 ? (<p>{`Days remaining to next feed cycle: ${nextCycleDates[3]} days`}</p>) : '' }
+
             {feedFreqJSX}
           </div>
 
@@ -140,6 +139,7 @@ CareFrequency.propTypes = {
   fertFreq: PropTypes.number.isRequired,
   feedFreq: PropTypes.any.isRequired,
   carnivorous: PropTypes.bool.isRequired,
+  nextCycleDates: PropTypes.array.isRequired,
   onChange: PropTypes.func,
 };
 

--- a/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
+++ b/src/frontend/containers/PlantProfilePage/CareFrequency.jsx
@@ -11,7 +11,7 @@ const getToday = () => {
 class CareFrequency extends React.PureComponent {
   constructor() {
     super();
-
+    console.log("callin care freq")
     this.markWatered = this.markWatered.bind(this);
     this.markFertilized = this.markFertilized.bind(this);
     this.markTurned = this.markTurned.bind(this);
@@ -39,7 +39,7 @@ class CareFrequency extends React.PureComponent {
   }
 
   render() {
-    const { pet, waterFreq, fertFreq, feedFreq, carnivorous, dead } = this.props;
+    const { pet, waterFreq, fertFreq, feedFreq, carnivorous, dead,nextCycleDates} = this.props;
 
     const today = getToday();
     const hasWateredToday = !!pet?.watered?.history?.[today];
@@ -71,6 +71,11 @@ class CareFrequency extends React.PureComponent {
             <p>{`Water Frequency: Every ${waterFreq} days`}</p>
             <p>{`Fertilize Frequency: Every ${fertFreq} days`}</p>
             <p>{`Turn Frequency: Every ${fertFreq} days`}</p>
+            <p>{`Days remaining to next water cycle: ${nextCycleDates[0]} days`}</p>
+            <p>{`Days remaining to next fertilize cycle: ${nextCycleDates[1]} days`}</p>
+            <p>{`Days remaining to next rotate cycle: ${nextCycleDates[2]} days`}</p>
+            {carnivorous===1 ? (<p>{`Days remaining to next feed cycle: ${nextCycleDates[3]} days`}</p>) : '' }
+            
             {feedFreqJSX}
           </div>
 

--- a/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
+++ b/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
@@ -14,7 +14,7 @@ class GeneralInformation extends React.PureComponent {
         <p>{`Description: ${description}`}</p>
         <p>{`Born: ${birth}`}</p>
         <p>{`Owned Since: ${ownedSince}`}</p>
-        {location != '' ? (<p>Plant's location: {location}</p>) : <p />}
+        {location !== '' ? (<p>Plant's location: {location}</p>) : <p />}
         {dead === 1 ? (<p>Dead Since: {death}</p>) : <p />}
       </div>
     );

--- a/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
+++ b/src/frontend/containers/PlantProfilePage/GeneralInformation.jsx
@@ -14,7 +14,7 @@ class GeneralInformation extends React.PureComponent {
         <p>{`Description: ${description}`}</p>
         <p>{`Born: ${birth}`}</p>
         <p>{`Owned Since: ${ownedSince}`}</p>
-        <p>{`Plant's Location: ${location}`}</p>
+        {location != '' ? (<p>Plant's location: {location}</p>) : <p />}
         {dead === 1 ? (<p>Dead Since: {death}</p>) : <p />}
       </div>
     );

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -48,7 +48,6 @@ class PlantProfilePage extends React.Component {
   }
 
   componentDidMount() {
-    console.log('calling index');
     const { match: { params: { username, id } } } = this.props;
     const { history, store: { account: { username: ownUsername } } } = this.props;
 
@@ -117,8 +116,9 @@ class PlantProfilePage extends React.Component {
     this.setState({ location: pets[id].location });
   }
 
+  /* eslint-disable-next-line class-methods-use-this */
   getTargetDate(lastDate, daysToAdd) {
-    this.lastDate.setDate(lastDate.getDate() + daysToAdd);
+    lastDate.setDate(lastDate.getDate() + daysToAdd);
     const futureDate = lastDate.toISOString().split('T')[0];
 
     const diffTime = Math.abs(new Date(futureDate) - new Date());
@@ -130,7 +130,6 @@ class PlantProfilePage extends React.Component {
   }
 
   getNextCycle() {
-    console.log('ok');
     const { match: { params: { id } } } = this.props;
     const { store: { pets } } = this.props;
     const { store: { plants } } = this.props;

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -117,16 +117,14 @@ class PlantProfilePage extends React.Component {
   }
 
   /* eslint-disable-next-line class-methods-use-this */
-  getTargetDate(lastDate, daysToAdd) {
-    lastDate.setDate(lastDate.getDate() + daysToAdd);
-    const futureDate = lastDate.toISOString().split('T')[0];
-
-    const diffTime = Math.abs(new Date(futureDate) - new Date());
+  getTargetDate(date, daysToAdd) {
+    date.setDate(date.getDate() + daysToAdd);
+    const diffTime = Math.abs(date - new Date());
     let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    if (diffDays >= 1000) {
+    if (diffDays > daysToAdd) {
       diffDays = 0;
     }
-    return [futureDate, diffDays];
+    return [date, diffDays];
   }
 
   getNextCycle() {

--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -15,7 +15,6 @@ import CareFrequency from './CareFrequency';
 import CareCalendar from './CareCalendar';
 import GrowthPictures from './GrowthPictures';
 import ManagePlant from './ManagePlant';
-import { tsThisType } from '@babel/types';
 
 class PlantProfilePage extends React.Component {
   constructor(props) {
@@ -44,12 +43,12 @@ class PlantProfilePage extends React.Component {
       growthPics: {},
       eventList: [],
       location: '',
-      nextCycleDates:[]
+      nextCycleDates: [],
     };
   }
 
   componentDidMount() {
-    console.log("calling index")
+    console.log('calling index');
     const { match: { params: { username, id } } } = this.props;
     const { history, store: { account: { username: ownUsername } } } = this.props;
 
@@ -59,8 +58,6 @@ class PlantProfilePage extends React.Component {
     this.getGrowthPictures();
     this.getPlantLocation();
     this.getNextCycle();
-    
-    
 
     if (!username) return Promise.resolve();
     return setForeignUserPets(username, id).catch(() => history.push(`/${ownUsername}`));
@@ -120,44 +117,39 @@ class PlantProfilePage extends React.Component {
     this.setState({ location: pets[id].location });
   }
 
-  getTargetDate(lastDate,daysToAdd){
-    
-    lastDate.setDate(lastDate.getDate() + daysToAdd); 
-    var futureDate=lastDate.toISOString().split('T')[0];
+  getTargetDate(lastDate, daysToAdd) {
+    this.lastDate.setDate(lastDate.getDate() + daysToAdd);
+    const futureDate = lastDate.toISOString().split('T')[0];
 
     const diffTime = Math.abs(new Date(futureDate) - new Date());
     let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    if(diffDays>=1000){
-      diffDays=0
+    if (diffDays >= 1000) {
+      diffDays = 0;
     }
-    return [futureDate,diffDays];
-    
+    return [futureDate, diffDays];
   }
- 
-  getNextCycle(){
-    console.log("ok")
+
+  getNextCycle() {
+    console.log('ok');
     const { match: { params: { id } } } = this.props;
     const { store: { pets } } = this.props;
     const { store: { plants } } = this.props;
-    const type=pets[id].type;
-    const {nextCycleDates}=this.state;
-    let nextFeedDates=[];
-    const nextWaterDates=this.getTargetDate(new Date(pets[id].watered.last),plants[type].waterFreq)
-    const nextFertDates=this.getTargetDate(new Date(pets[id].fertilized.last),plants[type].fertFreq)
-    const nextTurnDates=this.getTargetDate(new Date(pets[id].turned.last),plants[type].rotateFreq)
-    if(plants[type].carnivorous===1){
-      nextFeedDates=this.getTargetDate(new Date(pets[id].fed.last),plants[type].feedFreq)
+    const { type } = pets[id];
+
+    let nextFeedDates = [];
+    const nextWaterDates = this.getTargetDate(new Date(pets[id].watered.last),
+      plants[type].waterFreq);
+    const nextFertDates = this.getTargetDate(new Date(pets[id].fertilized.last),
+      plants[type].fertFreq);
+    const nextTurnDates = this.getTargetDate(new Date(pets[id].turned.last),
+      plants[type].rotateFreq);
+    if (plants[type].carnivorous === 1) {
+      nextFeedDates = this.getTargetDate(new Date(pets[id].fed.last),
+        plants[type].feedFreq);
     }
-    
-    this.setState({nextCycleDates:[nextWaterDates[1],nextFertDates[1],nextTurnDates[1],nextFeedDates[1]]});
 
-
-
-    
-  
-    
-
-
+    this.setState({ nextCycleDates: [nextWaterDates[1], nextFertDates[1],
+      nextTurnDates[1], nextFeedDates[1]] });
   }
 
   fetchEventList() {
@@ -193,7 +185,7 @@ class PlantProfilePage extends React.Component {
     const { history, match: { params: { username, id } } } = this.props;
     const { speciesName, scientificName, description, carnivorous,
       waterFreq, fertFreq, feedFreq, eventList,
-      profilePic, growthPics, location,nextCycleDates } = this.state;
+      profilePic, growthPics, location, nextCycleDates } = this.state;
 
     let pet;
     let dead = false;
@@ -229,7 +221,7 @@ class PlantProfilePage extends React.Component {
               birth={pet?.birth}
               ownedSince={pet?.ownedSince}
               location={location}
-              
+
               dead={pet.dead ? pet.dead : 0}
               death={pet.death ? pet.death : ''}
             />


### PR DESCRIPTION
This feature displays the remaining days to the next action (water/fertilize/rotate/feed) under Care Frequency of the plant profile.
This PR also has some minor fixes: 
- doesn't list plant location if it not set by the user
- harcoded rotation freq has been changed to reflect rotateFreq of that plant from the database.
- for every new plant that hasn't been watered/fertilized/rotated/fed yet, the remaining days to the next cycle will be 0 by default.