### PR TITLE
Adds "backend" functions for genealogy functionality

### DIFF
--- a/src/frontend/containers/PlantProfilePage/index.jsx
+++ b/src/frontend/containers/PlantProfilePage/index.jsx
@@ -235,6 +235,7 @@ PlantProfilePage.propTypes = {
       username: PropTypes.string,
     }),
     pets: PropTypes.object.isRequired,
+    genealogy: PropTypes.object.isRequired,
     users: PropTypes.object.isRequired,
     plants: PropTypes.object.isRequired,
   }).isRequired,

--- a/src/frontend/store/map.js
+++ b/src/frontend/store/map.js
@@ -2,6 +2,7 @@ const mapStateToProps = (state) => ({
   store: {
     account: state.account,
     pets: state.pets.pets,
+    genealogy: state.pets.genealogy,
     plants: state.plants.plants,
     users: state.users.users,
   },

--- a/src/frontend/store/reducers/pets.js
+++ b/src/frontend/store/reducers/pets.js
@@ -3,12 +3,23 @@ import constants from '../const';
 // Make sure to add these to the map
 const initialState = {
   pets: {},
+  geneaology: {
+    families: [],
+    trees: {},
+  },
 };
 
 const pets = (state = initialState, action) => {
   switch (action.type) {
     case constants.SET_PETS:
-      return { ...state, pets: action.pets || {} };
+      return {
+        ...state,
+        pets: action.pets || {},
+        genealogy: {
+          families: action.families,
+          trees: action.trees,
+        },
+      };
 
     default:
       return state;


### PR DESCRIPTION
This PR:
- Adds a store function to construct the family trees for a user's pets
- Adds a function to get all potential parents for a given pet (must not already be in family, must be same type, and parent must be older)
- Adds a short Firebase function to set the parent for a given pet